### PR TITLE
fix ruby2ruby dependency, later versions break heckle

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== 1.4.4 / 2011-11-23
+
+* 1 bug fix:
+
+  * fixed Ruby2Ruby dependency and reference in README
+
 === 1.4.3 / 2009-06-23
 
 * 2 minor enhancements:

--- a/README.txt
+++ b/README.txt
@@ -22,7 +22,7 @@ It's like hiring a white-hat hacker to try to break into your server and making 
 
 == REQUIREMENTS:
 
-* ruby2ruby 1.1.2 or greater
+* ruby2ruby 1.2.2
 * ParseTree 1.6.1 or greater
 
 == INSTALL:

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Hoe.spec 'heckle' do
 
   clean_globs    << File.expand_path("~/.ruby_inline")
   extra_deps     << ['ParseTree', '>= 2.0.0']
-  extra_deps     << ['ruby2ruby', '>= 1.1.6']
+  extra_deps     << ['ruby2ruby', '1.2.2']
   extra_deps     << ['ZenTest', '>= 3.5.2']
   multiruby_skip << "1.9"
 end


### PR DESCRIPTION
Any version of ruby2ruby later than 1.2.2 causes a 'translate' error in heckle.
